### PR TITLE
Add basic support for retrying requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/kpurdon/apir
 
 go 1.15
 
-require github.com/stretchr/testify v1.6.1
+require (
+	github.com/hashicorp/go-retryablehttp v0.6.8
+	github.com/stretchr/testify v1.6.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,16 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
+github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pkg/requester/requester.go
+++ b/pkg/requester/requester.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 // ContentType is an http Content-Type value.
@@ -72,6 +75,14 @@ func SetClient(hc *http.Client) ClientOption {
 	}
 }
 
+// WithRetry sets the underlying *http.Client with one configured for automated retry.
+func WithRetry() ClientOption {
+	return func(c *Client) {
+		rc := retryablehttp.NewClient()
+		c.client = rc.StandardClient()
+	}
+}
+
 // NewClient creates a new Client with sane defaults and applies any given ClientOption methods.
 func NewClient(name string, options ...ClientOption) *Client {
 	c := &Client{
@@ -104,6 +115,11 @@ type Request struct {
 	req       *http.Request
 	api       *API
 	userAgent string
+}
+
+// URL returns the underlying *url.URL.
+func (r *Request) URL() *url.URL {
+	return r.req.URL
 }
 
 // RequestOption defines configuration options for a Request.

--- a/pkg/requester/requester_test.go
+++ b/pkg/requester/requester_test.go
@@ -3,6 +3,7 @@ package requester_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,8 +17,10 @@ import (
 )
 
 var (
-	csvServer  *httptest.Server
-	jsonServer *httptest.Server
+	csvServer      *httptest.Server
+	jsonServer     *httptest.Server
+	failOnceServer *httptest.Server
+	failOnceMap    = make(map[string]bool)
 )
 
 func TestMain(m *testing.M) {
@@ -33,6 +36,24 @@ func TestMain(m *testing.M) {
 		}
 	}))
 	defer jsonServer.Close()
+
+	failOnceServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var shouldFail bool
+		if _, ok := failOnceMap[r.URL.Path]; !ok {
+			shouldFail = true
+			failOnceMap[r.URL.Path] = true
+		}
+
+		if shouldFail {
+			w.WriteHeader(http.StatusBadGateway)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{"color":"red"}`)); err != nil {
+			panic(err)
+		}
+	}))
+	defer failOnceServer.Close()
 
 	os.Exit(m.Run()) //nolint:gocritic
 }
@@ -53,7 +74,7 @@ func TestClientNewRequest(t *testing.T) {
 	t.Skip("TODO")
 }
 
-func TestClientExecute_CSV(t *testing.T) {
+func TestClientExecute(t *testing.T) {
 	t.Run("csv", func(t *testing.T) {
 		client := requester.NewClient("test")
 		client.MustAddAPI("testcsv", discoverer.NewDirect(csvServer.URL),
@@ -88,4 +109,28 @@ func TestClientExecute_CSV(t *testing.T) {
 
 		assert.Equal(t, "red", data.Color)
 	})
+	t.Run("json-with-retry", func(t *testing.T) {
+		client := requester.NewClient("test", requester.WithRetry())
+		client.MustAddAPI("testjson-retry", discoverer.NewDirect(failOnceServer.URL),
+			requester.SetContentType(requester.ApplicationJSON))
+
+		req, err := client.NewRequest(context.TODO(), "testjson-retry", http.MethodGet,
+			fmt.Sprintf("/%s", t.Name()), nil)
+		require.NoError(t, err)
+		assert.NotNil(t, req)
+
+		var data struct {
+			Color string `json:"color"`
+		}
+		ok, err := client.Execute(req, &data, nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+
+		assert.Equal(t, "red", data.Color)
+		assert.True(t, failOnceMap[req.URL().Path], "did not fail+retry")
+	})
+}
+
+func TestRequestURL(t *testing.T) {
+	t.Skip("TODO")
 }


### PR DESCRIPTION
Adds basic support for retrying requests using https://github.com/hashicorp/go-retryablehttp.

```go
requester.NewClient("test", requester.WithRetry())
```