### PR TITLE
User With* over Set* for functional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ A simple package for making/consuming api[r] requests/responses.
 ```go
 client := requester.NewClient("myservice")
 client.MustAddAPI("otherservice", discoverer.NewDirect("http://foo.com/api"),
-		requester.SetContentType(requester.ApplicationJSON))
+	requester.WithRetry(),
+	requester.WithContentType(requester.ApplicationJSON),
+)
 ```
 
 ### Create a Request

--- a/pkg/requester/requester.go
+++ b/pkg/requester/requester.go
@@ -51,8 +51,8 @@ type API struct {
 // APIOption defines configuration options for an API.
 type APIOption func(*API)
 
-// SetContentType sets the ContentType for an API.
-func SetContentType(ct ContentType) APIOption {
+// WithContentType sets the ContentType for an API.
+func WithContentType(ct ContentType) APIOption {
 	return func(api *API) {
 		api.contentType = ct
 	}
@@ -68,8 +68,8 @@ type Client struct {
 // ClientOption defines configuration options for a Client.
 type ClientOption func(*Client)
 
-// SetClient sets the underlying *http.Client for a Client.
-func SetClient(hc *http.Client) ClientOption {
+// WithClient sets the underlying *http.Client for a Client.
+func WithClient(hc *http.Client) ClientOption {
 	return func(c *Client) {
 		c.client = hc
 	}
@@ -125,8 +125,8 @@ func (r *Request) URL() *url.URL {
 // RequestOption defines configuration options for a Request.
 type RequestOption func(*Request)
 
-// SetUserAgent sets the user agent to be used on the Request.
-func SetUserAgent(ua string) RequestOption {
+// WithUserAgent sets the user agent to be used on the Request.
+func WithUserAgent(ua string) RequestOption {
 	return func(r *Request) {
 		r.userAgent = ua
 	}
@@ -150,7 +150,7 @@ func (c *Client) NewRequest(ctx context.Context, apiName, method, url string, bo
 		req.Header.Set("Content-Type", api.contentType.String())
 	}
 
-	// set the default user agent (can be changed w/ the SetUserAgent option)
+	// set the default user agent (can be changed w/ the WithUserAgent option)
 	req.Header.Set("User-Agent", fmt.Sprintf("kpurdon/apir (for %s)", c.name))
 
 	r := &Request{req: req, api: api}

--- a/pkg/requester/requester_test.go
+++ b/pkg/requester/requester_test.go
@@ -78,7 +78,7 @@ func TestClientExecute(t *testing.T) {
 	t.Run("csv", func(t *testing.T) {
 		client := requester.NewClient("test")
 		client.MustAddAPI("testcsv", discoverer.NewDirect(csvServer.URL),
-			requester.SetContentType(requester.TextCSV))
+			requester.WithContentType(requester.TextCSV))
 
 		req, err := client.NewRequest(context.TODO(), "testcsv", http.MethodGet, "/", nil)
 		require.NoError(t, err)
@@ -94,7 +94,7 @@ func TestClientExecute(t *testing.T) {
 	t.Run("json", func(t *testing.T) {
 		client := requester.NewClient("test")
 		client.MustAddAPI("testjson", discoverer.NewDirect(jsonServer.URL),
-			requester.SetContentType(requester.ApplicationJSON))
+			requester.WithContentType(requester.ApplicationJSON))
 
 		req, err := client.NewRequest(context.TODO(), "testjson", http.MethodGet, "/", nil)
 		require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestClientExecute(t *testing.T) {
 	t.Run("json-with-retry", func(t *testing.T) {
 		client := requester.NewClient("test", requester.WithRetry())
 		client.MustAddAPI("testjson-retry", discoverer.NewDirect(failOnceServer.URL),
-			requester.SetContentType(requester.ApplicationJSON))
+			requester.WithContentType(requester.ApplicationJSON))
 
 		req, err := client.NewRequest(context.TODO(), "testjson-retry", http.MethodGet,
 			fmt.Sprintf("/%s", t.Name()), nil)


### PR DESCRIPTION
Standardizes to using `With*` naming over `Set*` naming for function options.