### PR TITLE
Ensure a default content type is set since it's required

### DIFF
--- a/pkg/requester/requester.go
+++ b/pkg/requester/requester.go
@@ -51,7 +51,7 @@ type API struct {
 // APIOption defines configuration options for an API.
 type APIOption func(*API)
 
-// WithContentType sets the ContentType for an API.
+// WithContentType sets the ContentType for an API. If not specified the default ApplicationJSON is used.
 func WithContentType(ct ContentType) APIOption {
 	return func(api *API) {
 		api.contentType = ct
@@ -115,6 +115,11 @@ func (c *Client) MustAddAPI(name string, discoverer Discoverer, options ...APIOp
 	api := &API{Discoverer: discoverer}
 	for _, option := range options {
 		option(api)
+	}
+
+	// if the WithContentType option was no applied ensure we set the default value of ApplicationJSON
+	if api.contentType == "" {
+		api.contentType = ApplicationJSON
 	}
 
 	c.apis[name] = api

--- a/pkg/requester/requester_test.go
+++ b/pkg/requester/requester_test.go
@@ -101,8 +101,7 @@ func TestClientExecute_CSV(t *testing.T) {
 
 func TestClientExecute_JSON(t *testing.T) {
 	client := requester.NewClient("test")
-	client.MustAddAPI("testjson", discoverer.NewDirect(jsonServer.URL),
-		requester.WithContentType(requester.ApplicationJSON))
+	client.MustAddAPI("testjson", discoverer.NewDirect(jsonServer.URL))
 
 	req, err := client.NewRequest(context.TODO(), "testjson", http.MethodGet, "/", nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Ensures a content type is always set, even if no specific value is specified. Defaults to ApplicationJSON.