### PR TITLE
Replace MustAddAPI with AddAPI and return an error

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.32
+          version: v1.41
   test:
     runs-on: ubuntu-latest
     needs: lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - wsl
     - gomnd
     - nlreturn
+    - exhaustivestruct
 
 # dont use the default exclusions
 issues:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kpurdon/apir
 go 1.15
 
 require (
-	github.com/hashicorp/go-retryablehttp v0.6.8
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,16 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
 github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
+github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/discoverer/direct_test.go
+++ b/pkg/discoverer/direct_test.go
@@ -9,10 +9,12 @@ import (
 )
 
 func TestNewDirect(t *testing.T) {
+	t.Parallel()
 	require.NotNil(t, discoverer.NewDirect("http://foo.bar/"))
 }
 
 func TestDirectURL(t *testing.T) {
+	t.Parallel()
 	u := "http://foo.bar/"
 	d := discoverer.NewDirect(u)
 	require.NotNil(t, d)

--- a/pkg/requester/requester.go
+++ b/pkg/requester/requester.go
@@ -37,12 +37,12 @@ type Discoverer interface {
 
 // Requester defines an interface for creating and executing requests to an API.
 type Requester interface {
-	MustAddAPI(apiName string, discoverer Discoverer, options ...APIOption)
+	AddAPI(apiName string, discoverer Discoverer, options ...APIOption) error
 	NewRequest(ctx context.Context, apiName, method, url string, body io.Reader, options ...RequestOption) (*Request, error)
 	Execute(req *Request, successData, errorData interface{}) (bool, error)
 }
 
-// API defines an API and is embedded in a Client via MustAddAPI.
+// API defines an API and is embedded in a Client via AddAPI.
 type API struct {
 	Discoverer
 	contentType ContentType
@@ -106,10 +106,15 @@ func NewClient(name string, options ...ClientOption) *Client {
 	return c
 }
 
-// MustAddAPI adds an API with the given name and Discover to the Client applying any given APIOption methods.
-func (c *Client) MustAddAPI(name string, discoverer Discoverer, options ...APIOption) {
+// AddAPI adds an API with the given name and Discover to the Client applying any given APIOption methods.
+func (c *Client) AddAPI(name string, discoverer Discoverer, options ...APIOption) error {
 	if _, ok := c.apis[name]; ok {
-		panic(fmt.Sprintf("api %q already initialized", name))
+		return errors.Errorf("api %q already initialized", name)
+	}
+
+	_, err := url.Parse(discoverer.URL())
+	if err != nil {
+		return errors.Errorf("discoverer does not return a valid url: %+v", err)
 	}
 
 	api := &API{Discoverer: discoverer}
@@ -123,6 +128,8 @@ func (c *Client) MustAddAPI(name string, discoverer Discoverer, options ...APIOp
 	}
 
 	c.apis[name] = api
+
+	return nil
 }
 
 // Request defines a http request to be made to an API.

--- a/pkg/requester/requester_mock.go
+++ b/pkg/requester/requester_mock.go
@@ -23,7 +23,7 @@ type MockClient struct { //nolint:maligned
 // AddAPI implements the Requester.MustAddAPI method.
 func (m *MockClient) AddAPI(apiName string, discoverer Discoverer, options ...APIOption) error {
 	m.AddAPIFnCalled = true
-	m.AddAPIFn(apiName, discoverer, options...)
+	return m.AddAPIFn(apiName, discoverer, options...)
 }
 
 // NewRequest implements the Requester.NewRequest method.

--- a/pkg/requester/requester_mock.go
+++ b/pkg/requester/requester_mock.go
@@ -10,8 +10,8 @@ var _ Requester = &MockClient{}
 
 // MockClient implements the Requester interface allowing for complete control over the returned values.
 type MockClient struct { //nolint:maligned
-	MustAddAPIFn       func(apiName string, discoverer Discoverer, options ...APIOption)
-	MustAddAPIFnCalled bool
+	AddAPIFn       func(apiName string, discoverer Discoverer, options ...APIOption) error
+	AddAPIFnCalled bool
 
 	NewRequestFn       func(ctx context.Context, apiName, method, url string, body io.Reader, options ...RequestOption) (*Request, error)
 	NewRequestFnCalled bool
@@ -20,10 +20,10 @@ type MockClient struct { //nolint:maligned
 	ExecuteFnCalled bool
 }
 
-// MustAddAPI implements the Requester.MustAddAPI method.
-func (m *MockClient) MustAddAPI(apiName string, discoverer Discoverer, options ...APIOption) {
-	m.MustAddAPIFnCalled = true
-	m.MustAddAPIFn(apiName, discoverer, options...)
+// AddAPI implements the Requester.MustAddAPI method.
+func (m *MockClient) AddAPI(apiName string, discoverer Discoverer, options ...APIOption) error {
+	m.AddAPIFnCalled = true
+	m.AddAPIFn(apiName, discoverer, options...)
 }
 
 // NewRequest implements the Requester.NewRequest method.


### PR DESCRIPTION
Drops the panic-driven `MustAddAPI` in favor of an error-driven `AddAPI`.